### PR TITLE
increment txNonce before calling exec to mitigate reentrancy.

### DIFF
--- a/contracts/Delay.sol
+++ b/contracts/Delay.sol
@@ -172,8 +172,8 @@ contract Delay is Modifier {
             txHash[txNonce] == getTransactionHash(to, value, data, operation),
             "Transaction hashes do not match"
         );
-        require(exec(to, value, data, operation), "Module transaction failed");
         txNonce++;
+        require(exec(to, value, data, operation), "Module transaction failed");
     }
 
     function skipExpired() public {


### PR DESCRIPTION
Increment txNonce before calling exec to mitigate reentrancy which could lead to one transaction being executed multiple times, skipping other transactions in the process.